### PR TITLE
DB initialization changed

### DIFF
--- a/src/main/java/iudx/catalogue/CatalogueServer.java
+++ b/src/main/java/iudx/catalogue/CatalogueServer.java
@@ -4,9 +4,7 @@ import java.util.logging.Logger;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import iudx.catalogue.apiserver.APIServerVerticle;
-import iudx.catalogue.database.DatabaseInterface;
 import iudx.catalogue.database.DatabaseVerticle;
-import iudx.catalogue.database.MongoDB;
 import iudx.catalogue.validator.Validator;
 import iudx.catalogue.validator.ValidatorInterface;
 import iudx.catalogue.validator.ValidatorVerticle;
@@ -16,13 +14,12 @@ public class CatalogueServer {
   private static final Logger logger = Logger.getLogger(CatalogueServer.class.getName());
 
   public static void main(String[] args) {
-    // TODO Auto-generated method stub
 
     int procs = Runtime.getRuntime().availableProcessors();
     Vertx vertx = Vertx.vertx();
 
-    DatabaseInterface db = new MongoDB("items", "schemas");
-    vertx.deployVerticle(new DatabaseVerticle(db));
+    String which_database = "mongo";
+    vertx.deployVerticle(new DatabaseVerticle(which_database));
 
     ValidatorInterface v = new Validator();
     vertx.deployVerticle(new ValidatorVerticle(v));

--- a/src/main/java/iudx/catalogue/database/DatabaseInterface.java
+++ b/src/main/java/iudx/catalogue/database/DatabaseInterface.java
@@ -2,9 +2,10 @@ package iudx.catalogue.database;
 
 import io.vertx.core.Future;
 import io.vertx.core.eventbus.Message;
-import io.vertx.core.json.JsonObject;
 
 public interface DatabaseInterface {
+
+  public void init_db();
 
   public void search_attribute(Future<Void> messageHandler, Message<Object> message);
 

--- a/src/main/java/iudx/catalogue/database/DatabaseVerticle.java
+++ b/src/main/java/iudx/catalogue/database/DatabaseVerticle.java
@@ -11,13 +11,18 @@ public class DatabaseVerticle extends AbstractVerticle {
   private String action;
   private DatabaseInterface db;
 
-  public DatabaseVerticle(DatabaseInterface db) {
-    this.db = db;
+  public DatabaseVerticle(String which_database) {
+    
+    if (which_database == "mongo") {
+      this.db = new MongoDB("items", "schemas");
+    }
   }
 
   @Override
   public void start(Future<Void> startFuture) {
-
+    
+    db.init_db();
+    
     logger.info("Database Verticle started!");
     vertx
         .eventBus()

--- a/src/main/java/iudx/catalogue/database/MongoDB.java
+++ b/src/main/java/iudx/catalogue/database/MongoDB.java
@@ -13,13 +13,20 @@ import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
 
 public class MongoDB extends AbstractVerticle implements DatabaseInterface {
+
   private MongoClient mongo;
+
   private String ITEM_COLLECTION, SCHEMA_COLLECTION;
 
   public MongoDB(String item_database, String schema_database) {
-    mongo = MongoClient.createShared(vertx, config());
+
     ITEM_COLLECTION = item_database;
     SCHEMA_COLLECTION = schema_database;
+  }
+
+  public void init_db() {
+
+    mongo = MongoClient.createShared(vertx, config());
   }
 
   private void mongo_find(
@@ -88,12 +95,14 @@ public class MongoDB extends AbstractVerticle implements DatabaseInterface {
   }
 
   private JsonObject encode_schema(JsonObject schema) {
+
     String[] temp = StringUtils.split(schema.encode(), "$");
     String encodedSchema = StringUtils.join(temp, "&");
     return new JsonObject(encodedSchema);
   }
 
   private JsonObject decode_schema(JsonObject encodedSchema) {
+
     String[] temp = StringUtils.split(encodedSchema.encode(), "&");
     String schema = StringUtils.join(temp, "$");
     return new JsonObject(schema);
@@ -101,6 +110,7 @@ public class MongoDB extends AbstractVerticle implements DatabaseInterface {
 
   @Override
   public void read_schema(Future<Void> messageHandler, Message<Object> message) {
+
     JsonObject m = (JsonObject) message.body();
     JsonObject query = new JsonObject();
 
@@ -120,6 +130,7 @@ public class MongoDB extends AbstractVerticle implements DatabaseInterface {
   }
 
   private JsonObject addNewAttributes(JsonObject doc, String version) {
+
     JsonObject updated = doc.copy();
     updated.put("Created", new java.util.Date());
     updated.put("Last modified on", new java.util.Date());
@@ -150,6 +161,7 @@ public class MongoDB extends AbstractVerticle implements DatabaseInterface {
 
   @Override
   public void write_schema(Future<Void> messageHandler, Message<Object> message) {
+
     JsonObject request_body = (JsonObject) message.body();
 
     mongo.insert(


### PR DESCRIPTION
There was a null pointer exception happened when initializing the db in `CatalougeServer`.  
    `config()` used while creating the mongoclient is dependent on a private variable `context` of AbstractVerticle.  
    `context` is initialized by vert.x when verticle is deployed, we were using it before deployment of the verticle.  