### PR TITLE
Implemented case insensitive search for tags

### DIFF
--- a/src/main/java/iudx/catalogue/database/MongoDB.java
+++ b/src/main/java/iudx/catalogue/database/MongoDB.java
@@ -79,8 +79,9 @@ public class MongoDB extends AbstractVerticle implements DatabaseInterface {
       }
     }
 
-    // Do not output the _id field of mongo
+    // Do not output the _id and _tags field of mongo
     fields.put("_id", 0);
+    fields.put("_tags", 0);
 
     // Populate fields
     if (request_body.containsKey("attributeFilter")) {


### PR DESCRIPTION
[1] Stores a `_tag` field internally which has the values of `tags` in lowecase.